### PR TITLE
mapcompute/mapexec

### DIFF
--- a/src/parallelism.jl
+++ b/src/parallelism.jl
@@ -2,7 +2,44 @@ lazy(f; kw...) = delayed(f; kw...)
 
 # If any input is lazy, make the output lazy
 maybe_lazy(f, x) = any(x->x isa Union{Thunk, Chunk}, x) ? lazy(f)(x...) : f(x...)
+
 maybe_lazy(f) = (x...) -> maybe_lazy(f, x)
+
+function mapcompute(xs;
+                    cache=false,
+                    collect_results=identity,
+                    map=map, kw...)
+    thunks = []
+    map(xs) do x
+        if x isa Thunk
+            if cache
+                x.cache = true
+            end
+            push!(thunks, x)
+        end
+        x
+    end
+
+    vals = collect_results(compute(delayed((xs...)->[xs...]; meta=true)(thunks...); kw...))
+
+    i = 0
+    map(xs) do x
+        if x isa Thunk
+            i += 1
+            vals[i]
+        else
+            x
+        end
+    end
+end
+
+function mapexec(xs; cache=false, map=map)
+    mapcompute(xs;
+               map=map,
+               cache=cache,
+               collect_results=xs -> asyncmap(exec, xs))
+end
+
 
 """
     compute(tree::FileTree; cache=true)
@@ -11,28 +48,11 @@ Compute any lazy values (Thunks) in `tree` and return a new tree where the value
 the computed values (maybe on remote processes). The tree still behaves as a Lazy tree. `exec` on it will fetch the values from remote processes.
 """
 compute(d::FileTree; cache=true, kw...) = compute(Dagger.Context(), d; cache=cache, kw...)
+
 function compute(ctx, d::FileTree; cache=true, kw...)
-    thunks = []
-    mapvalues(d; lazy=false) do x
-        if x isa Thunk
-            if cache
-                x.cache = true
-            end
-            push!(thunks, x)
-        end
-    end
-
-    vals = compute(delayed((xs...)->[xs...]; meta=true)(thunks...); kw...)
-
-    i = 0
-    mapvalues(d; lazy=false) do x
-        i += 1
-        vals[i]
-    end
+    mapcompute(d, map=((f,t) -> mapvalues(f, t; lazy=false)), cache=cache; kw...)
 end
 
-exec(d::FileTree) = mapvalues(exec, compute(d, cache=false); lazy=false)
-exec(d::Union{Thunk, Chunk}) = collect(compute(d))
 """
     exec(x)
 
@@ -41,3 +61,7 @@ If `x` is a `Thunk` (such as the result of a `reducevalues`), then exec will com
 If `x` is anything else, `exec` just returns the same value.
 """
 exec(x) = x
+
+exec(d::FileTree) = mapexec(d, map=(f,t) -> mapvalues(f, t; lazy=false))
+
+exec(d::Union{Thunk, Chunk}) = collect(compute(d))


### PR DESCRIPTION
Given a collection with a `map` function which applies a function in a specific order, go through the collection and compute all thunks in parallel. Once done, replace the thunks with the result again using `map`.