### PR TITLE
Fix compute out of bounds when tree contains non-thunks

### DIFF
--- a/src/parallelism.jl
+++ b/src/parallelism.jl
@@ -26,8 +26,13 @@ function compute(ctx, d::FileTree; cache=true, kw...)
 
     i = 0
     mapvalues(d; lazy=false) do x
-        i += 1
-        vals[i]
+        # Expression returns vals[i] or x
+        if x isa Thunk
+            i += 1
+            vals[i]
+        else
+            x
+        end
     end
 end
 


### PR DESCRIPTION
Fixes #21 

Maybe there is a nicer way to do this, but I didn't want to disrupt (and think :) )

Its kinda untested beyond trivial trees so I'm a bit relying on the existing test suite.

Oh, also sorry for kinda diluting the contributors list with trivial fixes. Not sure if it is bad open source etiquette or the way things are supposed to be :).