### PR TITLE
fix reduce on empty collections

### DIFF
--- a/src/values.jl
+++ b/src/values.jl
@@ -119,5 +119,5 @@ function save(f, t::Node; lazy=nothing, exec=true)
     end
 
     # placeholder task that waits and returns nothing
-    (exec ? FileTrees.exec : identity)(reducevalues((x,y)->nothing, t′))
+    (exec ? FileTrees.exec : identity)(reducevalues((x,y)->nothing, t′, init=nothing))
 end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -172,11 +172,15 @@ end
         rm("test_dir_lazy", recursive=true)
     end
 
+    # issue 16
     @test_throws ArgumentError reducevalues(+, maketree("." => []))
     @test reducevalues(+, maketree("." => []), init=0) === 0
 
     @test_throws ArgumentError reducevalues(+, maketree("." => []), associative=false)
     @test reducevalues(+, maketree("." => []), init=0, associative=false) === 0
+
+    # issue 23
+    @test FileTrees.save(identity, maketree([])) == nothing
 end
 
 

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -171,6 +171,12 @@ end
     if isdir("test_dir_lazy")
         rm("test_dir_lazy", recursive=true)
     end
+
+    @test_throws ArgumentError reducevalues(+, maketree("." => []))
+    @test reducevalues(+, maketree("." => []), init=0) === 0
+
+    @test_throws ArgumentError reducevalues(+, maketree("." => []), associative=false)
+    @test reducevalues(+, maketree("." => []), init=0, associative=false) === 0
 end
 
 

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -125,6 +125,16 @@ end
     if isdir("test_dir")
         rm("test_dir", recursive=true)
     end
+
+    # issue 16
+    @test_throws ArgumentError reducevalues(+, maketree("." => []))
+    @test reducevalues(+, maketree("." => []), init=0) === 0
+
+    @test_throws ArgumentError reducevalues(+, maketree("." => []), associative=false)
+    @test reducevalues(+, maketree("." => []), init=0, associative=false) === 0
+
+    # issue 23
+    @test FileTrees.save(identity, maketree([])) == nothing
 end
 
 @testset "lazy-exec" begin
@@ -171,16 +181,6 @@ end
     if isdir("test_dir_lazy")
         rm("test_dir_lazy", recursive=true)
     end
-
-    # issue 16
-    @test_throws ArgumentError reducevalues(+, maketree("." => []))
-    @test reducevalues(+, maketree("." => []), init=0) === 0
-
-    @test_throws ArgumentError reducevalues(+, maketree("." => []), associative=false)
-    @test reducevalues(+, maketree("." => []), init=0, associative=false) === 0
-
-    # issue 23
-    @test FileTrees.save(identity, maketree([])) == nothing
 end
 
 


### PR DESCRIPTION
allow use of `init` in `reducevalues`

closes #16 
closes #23 