### PR TITLE
Add option to supply Context to Dagger

### DIFF
--- a/src/parallelism.jl
+++ b/src/parallelism.jl
@@ -38,7 +38,7 @@ function mapexec(ctx, xs; cache=false, map=map)
     mapcompute(ctx, xs;
                map=map,
                cache=cache,
-               collect_results=xs -> asyncmap(exec, xs))
+               collect_results=xs -> asyncmap(d -> exec(ctx, d), xs))
 end
 
 

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -196,16 +196,22 @@ end
 
     struct SpecialContext end
     
-    contextpropagated = Ref(false)
+    computespecial = Ref(false)
     function Dagger.compute(::SpecialContext, t::Dagger.Thunk, kws...)
-        contextpropagated[] = true
+        computespecial[] = true
         compute(Dagger.Context(), t; kws...)
+    end
+    ncollectspecial = Ref(0)
+    function Dagger.collect(::SpecialContext, c::Dagger.Chunk; kws...) 
+        ncollectspecial[] += 1
+        collect(Dagger.Context(), c; kws...)
     end
     
     t = mapvalues(identity, maketree("a" => ["b" => [(name="c", value=1)], "d" => ["e" => [(name="f", value=2), (name="g", value=3)]]]), lazy=true)
     
     @test exec(SpecialContext(), t) |> values == [1,2,3] 
-    @test contextpropagated[] == true # Dummy compare to make failed test outprint a little less confusing
+    @test computespecial[] == true # Dummy compare to make failed test outprint a little less confusing 
+    @test ncollectspecial[] == 3 # All values are collected with SpecialContext
 end
 
 

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -199,19 +199,30 @@ end
     computespecial = Ref(false)
     function Dagger.compute(::SpecialContext, t::Dagger.Thunk, kws...)
         computespecial[] = true
-        compute(Dagger.Context(), t; kws...)
+        compute(Dagger.Context(procs()), t; kws...)
     end
     ncollectspecial = Ref(0)
     function Dagger.collect(::SpecialContext, c::Dagger.Chunk; kws...) 
         ncollectspecial[] += 1
-        collect(Dagger.Context(), c; kws...)
+        collect(Dagger.Context(procs()), c; kws...)
     end
-    
+
+    # Stuff to make sure we never create a default Context
+    didfallback = Ref(false)
+    function Dagger.Context() 
+        didfallback[] = true
+        return Dagger.Context(procs())
+    end
+    # This should probably be fixed in Dagger so it takes the context as an argument
+    Dagger.collect_remote(chunk::Dagger.Chunk) = 
+    Dagger.move(Dagger.Context(procs()), chunk.processor, Dagger.OSProc(), Dagger.poolget(chunk.handle))
+
     t = mapvalues(identity, maketree("a" => ["b" => [(name="c", value=1)], "d" => ["e" => [(name="f", value=2), (name="g", value=3)]]]), lazy=true)
     
     @test exec(SpecialContext(), t) |> values == [1,2,3] 
     @test computespecial[] == true # Dummy compare to make failed test outprint a little less confusing 
     @test ncollectspecial[] == 3 # All values are collected with SpecialContext
+    @test didfallback[] == false # We never tried to create a normal Context
 end
 
 

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -191,6 +191,23 @@ end
     end
 end
 
+@testset "exec with context" begin
+    import Dagger
+
+    struct SpecialContext end
+    
+    contextpropagated = Ref(false)
+    function Dagger.compute(::SpecialContext, t::Dagger.Thunk, kws...)
+        contextpropagated[] = true
+        compute(Dagger.Context(), t; kws...)
+    end
+    
+    t = mapvalues(identity, maketree("a" => ["b" => [(name="c", value=1)], "d" => ["e" => [(name="f", value=2), (name="g", value=3)]]]), lazy=true)
+    
+    @test exec(SpecialContext(), t) |> values == [1,2,3] 
+    @test contextpropagated[] == true # Dummy compare to make failed test outprint a little less confusing
+end
+
 
 @testset "iterators" begin
     @test values(t1) == map(get, filter(hasvalue, nodes(t1)))


### PR DESCRIPTION
Fixes #32

I don’t love the mocking-ish testcase, but I couldn’t think of another way to test that it is propagated correctly.

I chose to only make the exported compute functions (`exec` and `compute`) have non-context versions. Let me know if you prefer it for any other method as well.

I will run some more tests for my use case just to make sure and I’ll post right back here once I have done so.
