### PR TITLE
Remove overwriting of Dagger functions in test

### DIFF
--- a/test/basics.jl
+++ b/test/basics.jl
@@ -207,22 +207,11 @@ end
         collect(Dagger.Context(procs()), c; kws...)
     end
 
-    # Stuff to make sure we never create a default Context
-    didfallback = Ref(false)
-    function Dagger.Context() 
-        didfallback[] = true
-        return Dagger.Context(procs())
-    end
-    # This should probably be fixed in Dagger so it takes the context as an argument
-    Dagger.collect_remote(chunk::Dagger.Chunk) = 
-    Dagger.move(Dagger.Context(procs()), chunk.processor, Dagger.OSProc(), Dagger.poolget(chunk.handle))
-
     t = mapvalues(identity, maketree("a" => ["b" => [(name="c", value=1)], "d" => ["e" => [(name="f", value=2), (name="g", value=3)]]]), lazy=true)
     
     @test exec(SpecialContext(), t) |> values == [1,2,3] 
     @test computespecial[] == true # Dummy compare to make failed test outprint a little less confusing 
     @test ncollectspecial[] == 3 # All values are collected with SpecialContext
-    @test didfallback[] == false # We never tried to create a normal Context
 end
 
 


### PR DESCRIPTION
I just realized that the "overloading" of the Dagger functions in the 'exec with context' test are permanent. This is bound to cause confusing failures in the future so here I think they should be removed even if it makes the test slightly less protective.

I somehow naively thought that all that happens in testset stays in testset, but this is not true for globals.