### PR TITLE
Set Dagger compat bounds to include 0.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"
 
 [compat]
 AbstractTrees = "0.3"
-Dagger = "0.9"
+Dagger = "0.9, 0.10"
 FilePathsBase = "0.9"
 Glob = "1.3"
 julia = "1"


### PR DESCRIPTION
Would installing CompatHelper be a good idea?