### PR TITLE
Fix inconsistent trees from getindex and merge.

### DIFF
--- a/src/patterns.jl
+++ b/src/patterns.jl
@@ -7,7 +7,7 @@ function Base.getindex(t::FileTree, g::GlobMatch)
     if sub === nothing
         error("$g did not match in tree")
     end
-    sub
+    setparent(sub)
 end
 
 _occursin(p::AbstractString, x) = p == x
@@ -31,7 +31,7 @@ function _glob_map(yes, no, t::FileTree, p, ps...)
         if isempty(cs)
             return no(t)
         else
-            return FileTree(t, children=cs) |> setparent
+            return FileTree(t, children=cs)
         end
     else
         return no(t)
@@ -53,7 +53,7 @@ Surround the regular expression in `^` and `\$` (to match the entire string).
 
 function Base.getindex(x::Union{FileTree, File}, regex::Regex)
     t = _regex_map(identity, x->nothing, x, regex)
-    isnothing(t) ?  empty(x) : t
+    isnothing(t) ?  empty(x) : setparent(t)
 end
 
 function _regex_map(yes, no, t::FileTree, regex::Regex, toplevel=true)

--- a/src/patterns.jl
+++ b/src/patterns.jl
@@ -31,7 +31,7 @@ function _glob_map(yes, no, t::FileTree, p, ps...)
         if isempty(cs)
             return no(t)
         else
-            return FileTree(t, children=cs)
+            return FileTree(t, children=cs) |> setparent
         end
     else
         return no(t)
@@ -73,7 +73,7 @@ function _regex_map(yes, no, t::FileTree, regex::Regex, toplevel=true)
     if isempty(cs)
         return no(t)
     else
-        return FileTree(t; children=cs)
+        return FileTree(t; children=cs) |> setparent
     end
 end
 

--- a/src/tree-ops.jl
+++ b/src/tree-ops.jl
@@ -28,8 +28,12 @@ end
 # path use `combine` to overwrite multiple files which map to the same path
 function regex_rewrite_tree(tree, from_path, to_path, combine)
     newtree = maketree(name(tree)=>[])
+    # Exclude the root from the matching because
+    #   1) the public API where the pattern is relative to the root and 
+    #   2) attach wants a path relative to the root
+    rootoffset = length(canonical_path(path(tree)))+2
     for x in Leaves(tree)
-        newname = replace(canonical_path(path(x)), from_path => to_path)
+        newname = replace(canonical_path(path(x))[rootoffset:end], from_path => to_path)
         dir = dirname(newname)
         dir = isempty(dir) ? "." : dir
         newtree = attach(newtree,
@@ -84,7 +88,7 @@ function normdots(x::FileTree; combine=_merge_error)
         z=normdots(y; combine=combine)
         name(z) == "." ? children(z) : [z]
     end |> Iterators.flatten |> collect
-    FileTree(x; children=_combine(c2, combine))
+    FileTree(x; children=_combine(c2, combine)) |> setparent
 end
 
 normdots(x::File; kw...) = x


### PR DESCRIPTION
Fixes #39 

Testing revealed that the root issue is that `getindex` for both globs and regexps returns a tree where the children of the root does not have the root as parent. Same thing also happens after `merge`.

Not sure if this is intentional, but it seems to me that a tree like this is inconsistent and should be considered invalid. Another option could be to add a call to `setparent` in the convenience “copy” constructor for `FileTree` if one wants to be really strict about not allowing such trees.

It turned out that `mv` and `cp` (or in fact ` regex_rewrite_tree` and `attach`) relied on this behavior to leave the root out of all processing. I first tried to change `attach` to not add the root node (i.e last line changed to `merge(t, t1; combine=combine)` and assume that `path` argument included the path to the root. 

This did however cause problems when root node is a subdirectory as it would change the tree to use the root of the root node as, uhm, root (i.e if root node has path a/b then the returned tree would have `a` as root and `b` as its child). This also had the adverse consequence that the public API for `mv` and `cp` would break as regexes where now matched against the whole path including the root node. Both these problems where caught by the `mv` tests in taxi.jl. 

Instead I resorted to just truncating the canonical path from behind in `regex_rewrite_tree`. Not sure if this is the most elegant way to do it.
