### PR TITLE
Preserve child order after merge

### DIFF
--- a/src/tree-ops.jl
+++ b/src/tree-ops.jl
@@ -65,19 +65,16 @@ end
 apply_combine(f::OnNodes, x, y) = f(x, y)
 
 function _combine(cs, combine)
-    if !issorted(cs, by=name)
-        sort!(cs, by=name)
-    end
-    i = 0
-    prev = nothing
+    seen = Dict()
     out = []
     for c in cs
-        if prev == name(c)
+        prev = get(seen, name(c), nothing)
+        if prev !== nothing
             out[end] = apply_combine(combine, c, out[end])
         else
             push!(out, c)
+            seen[name(c)] = c
         end
-        prev = name(c)
     end
     map(identity, out)
 end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -60,6 +60,13 @@ end
 
 @testset "merge" begin
     @test isequal(merge(t,t), t)
+
+    # Check that we don't rearrange the tree more than necessary
+    t2 =  maketree(["b" => ["x"], "a" => ["y"]])
+    t3 =  maketree(["c" => ["x"], "a" => ["z"]])
+    @test name.(children(merge(t2, t3))) == ["b", "a", "c"]
+    @test name.(children(merge(t3, t2))) == ["c", "a", "b"]
+    @test isequal(merge(t2, t3), merge(t3,t2))
 end
 
 @testset "diff" begin


### PR DESCRIPTION
Fixes #44 

Just to not change up the tree more than necessary. Should have the same behaviour as `Base.union` w.r.t ordering now.