### PR TITLE
Add associative keyword for mv and cp

### DIFF
--- a/test/basics.jl
+++ b/test/basics.jl
@@ -124,12 +124,16 @@ import FileTrees: attach
 
     @test isequal(t6, merge(t1, t5))
 
-    @testset "combine" begin
-        tcombine = maketree(["a" => [(name="y", value="ay"), (name ="x", value="ax")], "b" => [(name ="x", value="bx"), (name="y", value="by")]])
-        tcombined = mv(tcombine, r"^([^/]*)/([x|y])", s"\2"; combine=(v1,v2) -> v1 * "_" * v2)
+    @testset "$fun combine$(associative ? " associative" : "")" for fun in (cp, mv), associative in (false, true)
+        tcombine = maketree([
+                            "a" => [(name="y", value="ay"), (name ="x", value="ax")], 
+                            "b" => [(name ="x", value="bx"), (name="y", value="by")],
+                            "c" => [(name ="x", value="cx"), (name="y", value="cy")],
+                            ])
+        tcombined = mv(tcombine, r"^([^/]*)/([xy])", s"\2"; combine=(v1,v2) -> v1 * "_" * v2, associative=associative)
 
-        @test tcombined["x"][] == "ax_bx"
-        @test tcombined["y"][] == "ay_by"
+        @test tcombined["x"][] == "ax_bx_cx"
+        @test tcombined["y"][] == "ay_by_cy"
         # Also test that we maintained the same order as the first encountered node
         @test name.(children(tcombined)) == ["y", "x"]
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,8 +4,12 @@ using Distributed, .Threads
 if nprocs() == 1 && nthreads() == 1
     # Lazy stuff should also test distributed
     println("Adding a proc")
-    addprocs(1)
+    addprocs(1; exeflags="--project")
 end
 
 @testset "basics" begin include("basics.jl"); end
 @testset "taxi" begin include("taxi.jl"); end
+
+if nprocs() > 1
+    rmprocs(workers())
+end

--- a/test/taxi.jl
+++ b/test/taxi.jl
@@ -46,12 +46,18 @@ end
     # this should throw
     @test_throws ErrorException mv(dfs, r"^([^/]*)/([^/]*)/yellow.csv$", s"yellow.csv")
 
-    yellow = mv(dfs, r"^([^/]*)/([^/]*)/yellow.csv$", s"yellow.csv", combine=vcat)["yellow.csv"]
+    yellow = mv(dfs, r"^([^/]*)/([^/]*)/yellow.csv$", s"yellow.csv", combine=vcat, associative=false)["yellow.csv"]
     @test get(yellow) isa DataFrame
 
     # correct?
     @test Set(DataFrames.Tables.rowtable(reducevalues(vcat, dfs[glob"*/*/yellow.csv"]))) ==
     Set(DataFrames.Tables.rowtable(get(yellow)))
+
+    # Check that we get the same when not combining associatively
+    yellow_assoc = mv(dfs, r"^([^/]*)/([^/]*)/yellow.csv$", s"yellow.csv", combine=vcat, associative=true)["yellow.csv"]
+    @test get(yellow_assoc) isa DataFrame
+
+    @test dropmissing(get(yellow)) == dropmissing(get(yellow_assoc))
 end
 
 @testset "metadata" begin


### PR DESCRIPTION
Fixes #60 

This adds the `associative` keyword for `mv` and `cp` which makes `combine` applied recursively when there are multiple values that needs to be combined. This is the same as what is done for [`reducevalues`](https://github.com/shashi/FileTrees.jl/blob/0eb492a088ed2a0a320d008067dc9b0998030add/src/values.jl#L88) and enables more parallelism.

I chose a different default value compared to `reducevalues` to avoid breakage, but unless someone objects I'll change the default to be consistent with `reducevalues` in a subsequent breaking release.

@jpsamaroo :  I think this is a universal way to reduce in a parallel, but if you have time I appreciate a check that it's not just accidentally depending on some scheduler implementation detail.

Example:
```julia
julia> using FileTrees, Distributed

julia> addprocs(10; exeflags=["--project", "--threads=1"], lazy=false);

julia> @everywhere using FileTrees, Distributed

julia> @everywhere function myvcat(x, y)
                   @info "combine lengths $(length(x)) and $(length(y))"
                   sleep(1) # fake slowness
                   vcat(x,y)
               end

julia> tt = mapvalues(identity, maketree("root" => ["next" => [(name=string(x), value=1:10) for x in 'a':'k']]); lazy=true);

julia> ttm = mv(tt, r"next/[a-z]$", s"next"; combine=myvcat, associative=false);

julia> @time exec(ttm);
      From worker 8:    [ Info: combine lengths 10 and 10
      From worker 8:    [ Info: combine lengths 20 and 10
      From worker 8:    [ Info: combine lengths 30 and 10
      From worker 8:    [ Info: combine lengths 40 and 10
      From worker 8:    [ Info: combine lengths 50 and 10
      From worker 8:    [ Info: combine lengths 60 and 10
      From worker 8:    [ Info: combine lengths 70 and 10
      From worker 8:    [ Info: combine lengths 80 and 10
      From worker 8:    [ Info: combine lengths 90 and 10
      From worker 8:    [ Info: combine lengths 100 and 10
 11.606803 seconds (27.74 k allocations: 1.300 MiB)

julia> ttm_assoc = mv(tt, r"next/[a-z]$", s"next"; combine=myvcat, associative=true);

julia> @time exec(ttm_assoc);
      From worker 2:    [ Info: combine lengths 10 and 10
      From worker 4:    [ Info: combine lengths 10 and 10
      From worker 6:    [ Info: combine lengths 10 and 10
      From worker 2:    [ Info: combine lengths 10 and 10
      From worker 7:    [ Info: combine lengths 10 and 20
      From worker 4:    [ Info: combine lengths 10 and 20
      From worker 2:    [ Info: combine lengths 10 and 20
      From worker 4:    [ Info: combine lengths 20 and 30
      From worker 2:    [ Info: combine lengths 30 and 30
      From worker 2:    [ Info: combine lengths 50 and 60
  4.793218 seconds (43.04 k allocations: 2.158 MiB, 0.90% compilation time)
```
