### PR TITLE
Use assocreduce in mapcompute instead of splatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Manifest.toml
+.vscode

--- a/src/parallelism.jl
+++ b/src/parallelism.jl
@@ -9,7 +9,18 @@ function mapcompute(ctx, xs;
                     cache=false,
                     collect_results=identity,
                     map=map, kw...)
-    thunks = []
+
+    # Dagger does not have a way to just say "here is a bunch of Thunks, just compute them for me please"
+    # To make Dagger do this for us, we collect all Thunks in xs and ask Dagger to concatenate them into an array
+    # Once we have that array we just put the computed values back at the same place we found them
+    # Note that we rely on map visiting all elements in the same order each time it is called
+
+    # Creating all these intermediate arrys do have a little bit of overhead and I doubt this
+    # is the most efficient way of doing it. Hopefully if people end up here it is because they
+    # actually have heavy computations where the extra overhead is not significant
+
+    # Step 1: Collect  all thunks in xs
+    thunks = Thunk[]
     map(xs) do x
         if x isa Thunk
             if cache
@@ -20,8 +31,14 @@ function mapcompute(ctx, xs;
         x
     end
 
-    vals = collect_results(compute(ctx, delayed((xs...)->[xs...]; meta=true)(thunks...); kw...))
+    # Step 2: Ask Dagger to concatenate the results into vals
+    # We do assocreduce here mainly to prevent inference issues when xs is heterogenous
+    # Drawback vs e.g. splatting the whole array into a single delayed call to vcat is 
+    # that we end up creating a fair bit of intermediate arrays (about log2(length(thunks))).
+    vals = collect_results(compute(ctx, assocreduce(delayed(vcat; meta=true), thunks); kw...))
 
+    # Step 3: Put the computed results back at the same places we found them
+    # This is where we rely on map visiting all elements in the same order.
     i = 0
     map(xs) do x
         # Expression returns vals[i] or x
@@ -38,9 +55,11 @@ function mapexec(ctx, xs; cache=false, map=map)
     mapcompute(ctx, xs;
                map=map,
                cache=cache,
-               collect_results=xs -> asyncmap(d -> exec(ctx, d), xs))
+               collect_results=xs -> collect_chunks(ctx, xs))
 end
 
+collect_chunks(ctx, x) = [exec(ctx,x)]
+collect_chunks(ctx, xs::AbstractArray) = asyncmap(d -> exec(ctx,d), xs)
 
 """
     compute(tree::FileTree; cache=true)

--- a/src/values.jl
+++ b/src/values.jl
@@ -95,7 +95,7 @@ function assocreduce(f, xs; init=no_init)
     length(xs) == 1 && return xs[1]
     l = length(xs)
     m = div(l, 2)
-    f(assocreduce(f, xs[1:m]), assocreduce(f, xs[m+1:end]))
+    f(assocreduce(f, @view(xs[1:m])), assocreduce(f, @view(xs[m+1:end])))
 end
 
 """

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -140,100 +140,112 @@ import FileTrees: attach
 end
 
 @testset "values" begin
-    t1 = FileTrees.load(path, t)
-    if isdir("test_dir")
-        rm("test_dir", recursive=true)
-    end
 
-    @test get(t1["a/b/a"]) == string(p"." / "a" / "b" / "a")
+    mktempdir() do tmproot
+        basedir = joinpath(tmproot, "test_dir_values")
+        t1 = FileTrees.load(path, t)
 
-    @test reducevalues(*, mapvalues(lowercase, t1)) == lowercase(reducevalues(*, t1))
+        @test get(t1["a/b/a"]) == string(p"." / "a" / "b" / "a")
 
-    FileTrees.save(maketree("test_dir" => [t1])) do f
-        @test f isa File
-        open(path(f), "w") do io
-            print(io, get(f))
+        @test reducevalues(*, mapvalues(lowercase, t1)) == lowercase(reducevalues(*, t1))
+
+        FileTrees.save(maketree(basedir=> [t1])) do f
+            @test f isa File
+            open(path(f), "w") do io
+                print(io, get(f))
+            end
         end
-    end
 
-    t2 = FileTree("test_dir")
-    t3 = FileTrees.load(t2) do f
-        open(path(f), "r") do io
-            String(read(io))
+        t2 = FileTree(basedir)
+        t3 = FileTrees.load(t2) do f
+            open(path(f), "r") do io
+                String(read(io))
+            end
         end
+
+        t4 = filter(!isempty, t1)
+
+        @test isequal(t3, FileTrees.rename(t4, basedir))
+
+        x1 = maketree("a"=>[(name="b", value=1)])
+        x2 = mapvalues(x->NoValue(), x1, lazy=true)
+        @test !isempty(values(x2))
+        @test isempty(values(exec(x2)))
+        x3 = mapvalues(x->rand(), x2)
+        @test !isempty(values(x3))
+        @test isempty(values(exec(x3)))
+
+        # issue 16
+        @test_throws ArgumentError reducevalues(+, maketree("." => []))
+        @test reducevalues(+, maketree("." => []), init=0) === 0
+
+        @test_throws Union{ArgumentError,MethodError} reducevalues(+, maketree("." => []), associative=false)
+        @test reducevalues(+, maketree("." => []), init=0, associative=false) === 0
+
+        # issue 23
+        @test FileTrees.save(identity, maketree([])) == nothing
     end
-
-    t4 = filter(!isempty, t1)
-
-    @test isequal(t3, FileTrees.rename(t4, "test_dir"))
-    if isdir("test_dir")
-        rm("test_dir", recursive=true)
-    end
-
-    x1 = maketree("a"=>[(name="b", value=1)])
-    x2 = mapvalues(x->NoValue(), x1, lazy=true)
-    @test !isempty(values(x2))
-    @test isempty(values(exec(x2)))
-    x3 = mapvalues(x->rand(), x2)
-    @test !isempty(values(x3))
-    @test isempty(values(exec(x3)))
-
-    # issue 16
-    @test_throws ArgumentError reducevalues(+, maketree("." => []))
-    @test reducevalues(+, maketree("." => []), init=0) === 0
-
-    @test_throws Union{ArgumentError,MethodError} reducevalues(+, maketree("." => []), associative=false)
-    @test reducevalues(+, maketree("." => []), init=0, associative=false) === 0
-
-    # issue 23
-    @test FileTrees.save(identity, maketree([])) == nothing
 end
 
 @testset "lazy-exec" begin
+    mktempdir() do tmproot
+        basedir = joinpath(tmproot, "test_dir_lazy")
 
-    if isdir("test_dir_lazy")
-        rm("test_dir_lazy", recursive=true)
-    end
+        t1 = FileTrees.load(uppercase∘path, t, lazy=true)
 
+        @test get(t1["a/b/a"]) isa Thunk
+        @test get(exec(t1)["a/b/a"]) == string(p"."/"A"/"B"/"A")
+        # Exec a single File
+        @test get(exec(t1["a/b/a"])) == string(p"."/"A"/"B"/"A")
 
-    t1 = FileTrees.load(uppercase∘path, t, lazy=true)
+        @test exec(reducevalues(*, mapvalues(lowercase, t1))) == lowercase(exec(reducevalues(*, t1)))
 
-    @test get(t1["a/b/a"]) isa Thunk
-    @test get(exec(t1)["a/b/a"]) == string(p"."/"A"/"B"/"A")
-    # Exec a single File
-    @test get(exec(t1["a/b/a"])) == string(p"."/"A"/"B"/"A")
-
-    @test exec(reducevalues(*, mapvalues(lowercase, t1))) == lowercase(exec(reducevalues(*, t1)))
-
-    s = FileTrees.save(maketree("test_dir_lazy" => [t1])) do f
-        open(path(f), "w") do io
-            print(io, get(f))
+        s = FileTrees.save(maketree(basedir => [t1])) do f
+            open(path(f), "w") do io
+                print(io, get(f))
+            end
         end
-    end
-
-    @test isdir("test_dir_lazy")
-    @test isfile("test_dir_lazy/a/b/a")
+        @test isdir(basedir)
+        @test isfile(joinpath(basedir, "a", "b", "a"))
 
 
-    t2 = FileTree("test_dir_lazy")
-    t3 = FileTrees.load(t2; lazy=true) do f
-        open(path(f), "r") do io
-            (String(read(io)), now())
+        t2 = FileTree(basedir)
+        t3 = FileTrees.load(t2; lazy=true) do f
+            open(path(f), "r") do io
+                (String(read(io)), now())
+            end
         end
+        toc = now()
+        sleep(0.01)
+        tic = exec(reducevalues((x,y)->x, mapvalues(last, t3)))
+
+        @test tic > toc
+
+        t4 = filter(!isempty, t1) |> exec
+
+        t5 = mapvalues(first, t3) |> exec
+        @test isequal(t5, FileTrees.rename(t4, basedir))
     end
-    toc = now()
-    sleep(0.01)
-    tic = exec(reducevalues((x,y)->x, mapvalues(last, t3)))
+end
 
-    @test tic > toc
+@testset "lazy-exec heterogenous" begin
+    mktempdir() do tmproot
+        basedir = joinpath(tmproot, "test_dir_lazy")
 
-    t4 = filter(!isempty, t1) |> exec
+        smalltree = exec(FileTrees.load(maketree(basedir => [string(i) for i in 1:3]); lazy=true) do file
+                    isodd(parse(Int, name(file))) ? "AAA" : 13
+        end)
 
-    t5 = mapvalues(first, t3) |> exec
-    @test isequal(t5, FileTrees.rename(t4, "test_dir_lazy"))
+        @test unique(values(smalltree)[1:2:end]) == ["AAA"]
+        @test unique(values(smalltree)[2:2:end]) == [13]
 
-    if isdir("test_dir_lazy")
-        rm("test_dir_lazy", recursive=true)
+        # This used to create inference problems due to array of all values being splatted into a function
+        largetree = exec(FileTrees.load(maketree(basedir => [string(i) for i in 1:1200]); lazy=true) do file
+            isodd(parse(Int, name(file))) ? "AAA" : 13
+        end)
+
+        @test unique(values(largetree)[1:2:end]) == ["AAA"]
+        @test unique(values(largetree)[2:2:end]) == [13]
     end
 end
 


### PR DESCRIPTION
Fixes #72 

There is a fair bit of overhead here, more than 100% more when the tree is really large. One argument why this could be acceptable is that people might not use the lazy mode unless they have heavy computations in which case the overhead should not be significant. I don't see `assocreduce` popping up in the profile viewer either, so maybe it is just more work for Dagger to move the partial results around. 

I suppose one could have a more coarse grained splitting of the thunks array than going all the way down to a single element (e.g. doing the current splatting on up to 100-ish elements at the time). Not sure if it is worth the effort and extra moving parts though.

Benchmarks

4 Threads, no Distributed:
```julia
julia> smalltree = maketree("root" => [string(i) for i in 1:3]);

# Current main:
julia> @benchmark exec(FileTrees.load($Returns(1), $smalltree; lazy=true))
BenchmarkTools.Trial: 9588 samples with 1 evaluation.
 Range (min … max):  378.400 μs … 27.309 ms  ┊ GC (min … max): 0.00% … 64.64%
 Time  (median):     404.700 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   518.627 μs ±  1.306 ms  ┊ GC (mean ± σ):  9.67% ±  3.79%
 Memory estimate: 158.53 KiB, allocs estimate: 2728.

# With PR:
julia> @benchmark exec(FileTrees.load($Returns(1), $smalltree; lazy=true))
BenchmarkTools.Trial: 6720 samples with 1 evaluation.
 Range (min … max):  488.200 μs … 44.203 ms  ┊ GC (min … max): 0.00% … 74.48%
 Time  (median):     532.850 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   738.081 μs ±  1.742 ms  ┊ GC (mean ± σ):  9.43% ±  4.04%
 Memory estimate: 191.28 KiB, allocs estimate: 3320.

julia> mediumtree = maketree("root" => [string(i) for i in 1:1000]);

# Current main:
julia> @benchmark exec(FileTrees.load($Returns(1), $mediumtree; lazy=true))
BenchmarkTools.Trial: 75 samples with 1 evaluation.
 Range (min … max):  49.478 ms … 85.537 ms  ┊ GC (min … max):  0.00% … 21.06%
 Time  (median):     69.424 ms              ┊ GC (median):    21.73%
 Time  (mean ± σ):   66.818 ms ± 10.082 ms  ┊ GC (mean ± σ):  17.39% ± 10.23%
 Memory estimate: 41.53 MiB, allocs estimate: 572385.

# With PR:
julia> @benchmark exec(FileTrees.load($Returns(1), $mediumtree; lazy=true))
BenchmarkTools.Trial: 34 samples with 1 evaluation.
 Range (min … max):  136.017 ms … 174.173 ms  ┊ GC (min … max): 10.26% … 18.41%
 Time  (median):     143.190 ms               ┊ GC (median):    11.37%
 Time  (mean ± σ):   147.357 ms ±   9.639 ms  ┊ GC (mean ± σ):  13.47% ±  3.75%
 Memory estimate: 72.54 MiB, allocs estimate: 1133724.

julia> largetree = maketree("root" => [string(i) for i in 1:10000]);

# Current main:
julia> @benchmark exec(FileTrees.load($Returns(1), $largetree; lazy=true))
BenchmarkTools.Trial: 6 samples with 1 evaluation.
 Range (min … max):  806.612 ms …    1.073 s  ┊ GC (min … max): 22.84% … 35.78%
 Time  (median):     969.528 ms               ┊ GC (median):    31.32%
 Time  (mean ± σ):   960.597 ms ± 107.355 ms  ┊ GC (mean ± σ):  31.01% ±  6.69%
 Memory estimate: 489.02 MiB, allocs estimate: 6003015.

# With PR:
julia> @benchmark exec(FileTrees.load($Returns(1), $largetree; lazy=true))
BenchmarkTools.Trial: 3 samples with 1 evaluation.
 Range (min … max):  2.060 s …    2.708 s  ┊ GC (min … max): 25.88% … 31.11%
 Time  (median):     2.257 s               ┊ GC (median):    32.34%
 Time  (mean ± σ):   2.342 s ± 332.086 ms  ┊ GC (mean ± σ):  29.97% ±  3.43%
 Memory estimate: 928.02 MiB, allocs estimate: 11738336.
```

Distributed with 4 workers (single thread per worker):
```julia
julia> addprocs(4; exeflags=["--project=.", "-t 1"], lazy=false);

# Current main:
julia> @benchmark exec(FileTrees.load($Returns(1), $smalltree; lazy=true))
BenchmarkTools.Trial: 1323 samples with 1 evaluation.
 Range (min … max):  2.479 ms … 48.137 ms  ┊ GC (min … max): 0.00% … 27.85%
 Time  (median):     3.161 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   3.767 ms ±  3.109 ms  ┊ GC (mean ± σ):  2.54% ±  4.24%
 Memory estimate: 239.81 KiB, allocs estimate: 4244.

# With PR
julia> @benchmark exec(FileTrees.load($Returns(1), $smalltree; lazy=true))
BenchmarkTools.Trial: 803 samples with 1 evaluation.
 Range (min … max):  4.098 ms … 41.777 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     5.297 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   6.220 ms ±  3.890 ms  ┊ GC (mean ± σ):  2.03% ± 4.23%
 Memory estimate: 294.66 KiB, allocs estimate: 5232.

# Current main:
julia> @benchmark exec(FileTrees.load($Returns(1), $mediumtree; lazy=true))
BenchmarkTools.Trial: 2 samples with 1 evaluation.
 Range (min … max):  3.096 s …   3.139 s  ┊ GC (min … max): 1.29% … 1.51%
 Time  (median):     3.117 s              ┊ GC (median):    1.40%
 Time  (mean ± σ):   3.117 s ± 30.027 ms  ┊ GC (mean ± σ):  1.40% ± 0.16%
 Memory estimate: 182.52 MiB, allocs estimate: 6762341.

# With PR:
julia> @benchmark exec(FileTrees.load($Returns(1), $mediumtree; lazy=true))
BenchmarkTools.Trial: 2 samples with 1 evaluation.
 Range (min … max):  3.978 s …    4.406 s  ┊ GC (min … max): 1.67% … 2.08%
 Time  (median):     4.192 s               ┊ GC (median):    1.88%
 Time  (mean ± σ):   4.192 s ± 302.113 ms  ┊ GC (mean ± σ):  1.88% ± 0.29%
 Memory estimate: 236.52 MiB, allocs estimate: 7776384.

# Current main:
julia> @benchmark exec(FileTrees.load($Returns(1), $largetree; lazy=true))
BenchmarkTools.Trial: 1 sample with 1 evaluation.
 Single result which took 406.002 s (1.05% GC) to evaluate,
 with a memory estimate of 14.73 GiB, over 607986258 allocations.

With PR:
julia> @benchmark exec(FileTrees.load($Returns(1), $largetree; lazy=true))
BenchmarkTools.Trial: 1 sample with 1 evaluation.
 Single result which took 401.316 s (1.57% GC) to evaluate,
 with a memory estimate of 15.45 GiB, over 619338178 allocations.
```