### PR TITLE
Bump dagger to 0.17

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FileTrees"
 uuid = "72696420-646e-6120-6e77-6f6420746567"
 authors = ["Shashi Gowda <gowda@mit.edu>", "Julian Samaroo <jpsamaroo@jpsamaroo.me>"]
-version = "0.3.8"
+version = "0.3.9"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
@@ -11,7 +11,7 @@ Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"
 
 [compat]
 AbstractTrees = "0.3, 0.4"
-Dagger = "0.9, 0.10, 0.11, 0.12.3, 0.13, 0.14, 0.15, 0.16"
+Dagger = "0.9, 0.10, 0.11, 0.12.3, 0.13, 0.14, 0.15, 0.16, 0.17"
 FilePathsBase = "0.9"
 Glob = "1.3"
 julia = "1"


### PR DESCRIPTION
Seems like compat helper has been disabled. 