### PR TITLE
Faster ctor

### DIFF
--- a/.github/workflows/DeployPage.yml
+++ b/.github/workflows/DeployPage.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # <a href="http://shashi.biz/FileTrees.jl">FileTrees</a>
 
-[![Build Status](https://travis-ci.org/shashi/FileTrees.jl.svg?branch=master)](https://travis-ci.org/shashi/FileTrees.jl) [![Build status](https://ci.appveyor.com/api/projects/status/6sei8e7et721usx6?svg=true)](https://ci.appveyor.com/project/shashi/filetrees-jl)
- [![Coverage Status](https://coveralls.io/repos/github/shashi/FileTrees.jl/badge.svg?branch=master)](https://coveralls.io/github/shashi/FileTrees.jl?branch=master)
+[![CI](https://github.com/shashi/FileTrees.jl/actions/workflows/ci.yml/badge.svg)](https://github.com/shashi/FileTrees.jl/actions/workflows/ci.yml)
+[![Coverage Status](https://coveralls.io/repos/github/shashi/FileTrees.jl/badge.svg?branch=master)](https://coveralls.io/github/shashi/FileTrees.jl?branch=master)
  
 Easy everyday parallelism with a file tree abstraction.
 

--- a/src/datastructure.jl
+++ b/src/datastructure.jl
@@ -20,9 +20,11 @@ struct NoValue end
 
 Copy over all fields from `tree`, but use any fields provided as keyword arguments.
 
-    FileTree(dirname::String)
+    FileTree(dirname::String; [sort])
 
 Construct a `FileTree` to reflect directory from disk in the current working directory.
+
+If `sort=true` (the default) then each level of the tree will be lexicographically sorted.
 """
 struct FileTree
     parent::Union{FileTree, Nothing}
@@ -53,25 +55,25 @@ function FileTree(t::FileTree;
     FileTree(parent, name, children, value)
 end
 
-FileTree(dir) = FileTree(nothing, dir)
+FileTree(dir; kwargs...) = FileTree(nothing, dir; kwargs...)
 
-function FileTree(parent, dir)
-    children = []
-    parent′ = FileTree(parent, dir, children)
-
-    ls = readdir(dir)
-    cd(dir) do
-        children′ = map(ls) do f
-            if isdir(f)
-                FileTree(parent′, f)
-            else
-                File(parent′, f)
-            end
+function FileTree(parent, dir; sort=true, root="")
+    parent′ = FileTree(parent, dir, [])
+    for (path, dirs, files) in walkdir(joinpath(root, dir)) 
+        for dir in dirs
+            push!(parent′.children, FileTree(parent′, dir; sort, root=path))
         end
-        append!(children, children′)
+        for file in files
+            push!(parent′.children, File(parent′, file))
+        end
+        if sort 
+            sort!(parent′.children; by=name)
+        end
+        # this might look a bit silly, but we don't care much for walkdir recursing down the tree, only that it is
+        # much faster than readdir + isdir/isfile when it comes to separating files from directories 
+        break
     end
-
-    parent′
+    parent′ 
 end
 
 """


### PR DESCRIPTION
Fixes #84 

This uses walkdir which is much faster than readdir + isdir when it comes to separating files from directories. There were some attempts in the fixed issue to actually use the traversal of walkdir, but the current version has pretty much the same performance and does not rely on details about the iteration in the same way as the other options did.

@ghyatzo: Please verify if you can that this final version has acceptable performance for your usecase.