### PR TITLE
Filetree parallelfix

### DIFF
--- a/.github/workflows/DeployPage.yml
+++ b/.github/workflows/DeployPage.yml
@@ -36,9 +36,8 @@ jobs:
             import PkgPage;
             PkgPage.optimize(input="page", output="")'
     - name: Build and Deploy
-      uses: JamesIves/github-pages-deploy-action@releases/v3
+      uses: JamesIves/github-pages-deploy-action@v4
       with:
-        SSH: true
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        BRANCH: gh-pages
-        FOLDER: page/__site
+        token: ${{ secrets.GITHUB_TOKEN }}
+        branch: gh-pages
+        folder: page/__site

--- a/src/parallelism.jl
+++ b/src/parallelism.jl
@@ -35,7 +35,7 @@ If `x` is anything else, `exec` just returns the same value.
 exec(x) = exec(DEFAULT_EXEC_CONTEXT[], x)
 exec(e, x, args...) = x
 
-exec(e, d::FileTree, args...) = mapvalues(v -> exec(e, v, fetch), d; lazy=false)
+exec(e, d::FileTree, args...) = mapvalues(fetch, mapvalues(v -> exec(e, v, identity), d; lazy=false))
 exec(e, f::File, collect_results=fetch) = setvalue(f, exec(e, f[], collect_results))
 
 struct UnwrappedTaskException{E} <: Exception


### PR DESCRIPTION
The parallelism over all values in a FileTree was accidentally removed when I moved compute to the Dagger extension (as it is a Dagger function). This adds it back.

Also another attempt to fix the permissions issue for the doc build