### PR TITLE
Harmonize Path with empty filename between windows and linux.

### DIFF
--- a/src/datastructure.jl
+++ b/src/datastructure.jl
@@ -287,6 +287,8 @@ root node leading up to this file.
 """
 function Path(d::Node)
     parent(d) === nothing && return Path(d.name)
+    # Prevent that empty names become ".". Not 100 that this is always right, but at least is prevents mv from silently deleting them
+    isempty(d.name) && return Path(parent(d)) 
     Path(parent(d)) / Path(d.name)
 end
 

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -137,6 +137,23 @@ import FileTrees: attach
         # Also test that we maintained the same order as the first encountered node
         @test name.(children(tcombined)) == ["y", "x"]
     end
+
+    @testset "Unusual filenames" begin
+        # Some of these are generally not allowed on filesystems, but FileTrees handles them in other contexts
+        t = maketree("root" => [(name="", value=1), (name=".", value=2), (name="..", value=3), (name="a", value=4)])
+        
+        # All names are accepted at this stage
+        @test name.(files(t)) == ["", ".", "..", "a"]
+        @test reducevalues(vcat, t) == 1:4
+                
+        # Should be a noop
+        tmv = mv(t, r"(.*)", s"\1")
+
+        # The file named "." gets swallowed due to normdots which might be surprising. Maybe worth fixing in the future
+        @test name.(files(tmv)) == ["", "..", "a"]
+        @test reducevalues(vcat, tmv) == [1, 3, 4]
+
+    end
 end
 
 @testset "values" begin


### PR DESCRIPTION
This fixes inconsistent mv behaviour between windows and linux when filename is an empty string:

```julia
julia> t = maketree("root" => [(name="", value=1), (name="a", value=2)])
root/
├─  (Int64)
└─ a (Int64)
```

Before on linux:
```julia
julia> mv(t, r"(.*)", s"\1") # Noop mv
root/
└─ a (Int64)
```

After on linux (and before on windows):
```julia
julia> mv(t, r"(.*)", s"\1")
root/
├─  (Int64)
└─ a (Int64)
```
Not sure if empty names should even be allowed, but since they are, then I think `mv` should not silently delete them.